### PR TITLE
Filter strict loose

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Change entity repository to `RestRepository` or create new one.
 
     // Provide configured entity manager
     $entityManager = getEntityManager()
-    
+
     // Repository that action will work with
     $restRepository = new RestRepository($entityManager, $entityManager->getClassMetadata($entityClass));
 
@@ -52,9 +52,9 @@ Route request `GET http://localhost/api/{resourceKey}`
 
     /** @var RestResponse|Symfony\Component\HttpFoundation\Response */
     $response = $action->dispatch($restRequest);
- 
+
 Regular response
- 
+
     {
         'data': [
             { ...transformer data },
@@ -95,9 +95,9 @@ Route request `GET http://localhost/api/{resourceKey}/{id}`.
 
     /** @var RestResponse|Symfony\Component\HttpFoundation\Response */
     $response = $action->dispatch($restRequest);
- 
+
 Regular response
- 
+
     {
         'data': [
             'id': {id},
@@ -128,9 +128,9 @@ Route request `POST http://localhost/api/{resourceKey}`.
 
     /** @var RestResponse|Symfony\Component\HttpFoundation\Response */
     $response = $action->dispatch($restRequest);
- 
+
 Regular response
- 
+
     {
         'data': [
             'id': {id},
@@ -161,9 +161,9 @@ Route request `PATCH http://localhost/api/{resourceKey}/{id}`.
 
     /** @var RestResponse|Symfony\Component\HttpFoundation\Response */
     $response = $action->dispatch($restRequest);
- 
+
 Regular response
- 
+
     {
         'data': [
             'id': {id},
@@ -206,4 +206,10 @@ We using doctrine migrations for unit tests database schema.
 
 ```
 php ./vendor/bin/doctrine-migrations migrations:diff
+```
+
+## Run tests
+```
+docker-compose up -d
+docker-compose run php phpunit
 ```

--- a/src/Doctrine/Rest/Action/CollectionAction.php
+++ b/src/Doctrine/Rest/Action/CollectionAction.php
@@ -27,6 +27,13 @@ class CollectionAction extends RestAction
     protected $filterProperty;
 
     /**
+     * Either to apply a loose or strict search.
+     *
+     * @var bool
+     */
+    protected bool $filterPropertyStrict = false;
+
+    /**
      * Get list of filterable entity fields.
      *
      * @var array
@@ -38,9 +45,10 @@ class CollectionAction extends RestAction
      *
      * @return $this
      */
-    public function setFilterProperty($property)
+    public function setFilterProperty($property, bool $strict = false)
     {
         $this->filterProperty = $property;
+        $this->filterPropertyStrict = $strict;
         return $this;
     }
 
@@ -165,7 +173,7 @@ class CollectionAction extends RestAction
     protected function filterParsers(RestRequestContract $request)
     {
         return [
-            new SearchFilterParser($request, $this->getStringFilterField()),
+            new SearchFilterParser($request, $this->getStringFilterField(), $this->filterPropertyStrict),
             new ArrayFilterParser($request, $this->getArrayFilterFields()),
         ];
     }


### PR DESCRIPTION
Currently `SearchFilterParser` performs a loose search (`CONTAINS`).
This PR introduces the ability to ask for a strict search (`EQ`) so we have the best of both worlds with the ability to set a filter property.